### PR TITLE
fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pytest tests and example output are included for both versions.
 
 Example:
 ```
-from oppen_pretty_printer import pprint, Token as T
+from oppen_pretty_printer import pprint, Tokens as T
 
 tokens = [
     T.BEGIN(),


### PR DESCRIPTION
Even with the typo fixed it still doesn't work as expected:
```python
from oppen_pretty_printer import pprint, Tokens as T
tokens = [
    T.BEGIN(),
    T.STRING("begin"),
    T.STRING("x"),
    T.BREAK(), T.STRING(":="), T.BREAK(),
    T.STRING("40"),
    T.BREAK(), T.STRING("+"), T.BREAK(),
    T.STRING("2"),
    T.STRING("end"),
    T.END(),
    T.EOF()]
pprint(tokens)
```
This is the output:
```
'beginx := 40 + 2end'
```